### PR TITLE
ci(docker): Add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:alpine as builder
+RUN apk add clang musl-dev
+RUN cargo install convco
+
+FROM alpine as base
+COPY --from=builder /usr/local/cargo/bin/convco /usr/local/bin/convco
+
+ENTRYPOINT [ "convco" ]
+CMD [ "check" ]


### PR DESCRIPTION
To use CI with isolated steps, like gitlab, we need a docker image.
With this dockerfile, you will be able to run convco check in CI.
This image is used internally by Qonfucius to run convco check on many projects via gitlab CI.

As a reference, minimal config to do that : 
```yaml
convco:check:
  image:
    name: $CONTAINER_CUSTOM_REGISTRY/convco-alpine:latest
    entrypoint: [""]
  script:
    - convco check
```